### PR TITLE
API.css 1.0.0 Beta 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All relevant changes to API.css will be documented here.
 
+## [1.0.0-beta.3] - 2023-03-10
+
+### Added
+
+- Added root `_index.scss` as an accessible entry point into API.css.
+- Added `size` shorthand mixin for using the `size()` function across breakpoints.
+- Added `prefers-motion` media query mixin for when the user requests motion.
+
+### Changed
+
+- Changed `font-size` mixin parameter name from `$values` to intended `$steps`.
+- Changed `breakpoints` mixin by removing `$properties`, and to only accept `$values`.
+
 ## [1.0.0-beta.2] - 2023-03-04
 
 ### Added
@@ -39,6 +52,7 @@ All relevant changes to API.css will be documented here.
 
 - Initial beta release (cloned from Neo CSS preview branch).
 
+[1.0.0-beta.3]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.1
 [1.0.0-beta.0]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.0

--- a/_index.scss
+++ b/_index.scss
@@ -1,0 +1,2 @@
+// Index: Accessible entry point into API.css.
+@forward "scss/";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "api.css",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "api.css",
-			"version": "1.0.0-beta.2",
+			"version": "1.0.0-beta.3",
 			"license": "MIT",
 			"dependencies": {
 				"sass": "^1.58.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "api.css",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"description": "A modern CSS API built with SASS/SCSS.",
 	"keywords": [
 		"API.css",
@@ -13,6 +13,8 @@
 	"author": "Joshua Elijah Sandoval",
 	"files": [
 		"scss",
+		"_index.scss",
+		"CHANGELOG.md",
 		"LICENSE",
 		"README.md"
 	],

--- a/scss/api/mixins/_breakpoints.scss
+++ b/scss/api/mixins/_breakpoints.scss
@@ -1,4 +1,4 @@
-// Breakpoints: Scales $properties across the viewport breakpoints.
+// Breakpoints: Spreads $values across the viewport breakpoints.
 
 @use "../variables/" as *;
 @use "../sass" as *;

--- a/scss/api/mixins/_breakpoints.scss
+++ b/scss/api/mixins/_breakpoints.scss
@@ -5,11 +5,10 @@
 @use "declare" as *;
 @use "min-vw" as *;
 
-@mixin breakpoints($properties, $values...) {
+@mixin breakpoints($values...) {
     $values: LIST-zip($breakpoints, $values);
     @each $vw, $value in $values {
         @include min-vw($vw) {
-            @include declare($properties, $value);
             @content($value);
         }
     }

--- a/scss/api/mixins/_breakpoints.scss
+++ b/scss/api/mixins/_breakpoints.scss
@@ -2,7 +2,6 @@
 
 @use "../variables/" as *;
 @use "../sass" as *;
-@use "declare" as *;
 @use "min-vw" as *;
 
 @mixin breakpoints($values...) {

--- a/scss/api/mixins/_font-size.scss
+++ b/scss/api/mixins/_font-size.scss
@@ -3,8 +3,8 @@
 @use "../functions/" as *;
 @use "breakpoints" as *;
 
-@mixin font-size($values...) {
-	@include breakpoints(null, $values...) using ($size) {
-		font-size: font-size($size);
+@mixin font-size($steps...) {
+	@include breakpoints(null, $steps...) using ($step) {
+		font-size: font-size($step);
 	}
 }

--- a/scss/api/mixins/_font-size.scss
+++ b/scss/api/mixins/_font-size.scss
@@ -4,7 +4,7 @@
 @use "breakpoints" as *;
 
 @mixin font-size($steps...) {
-	@include breakpoints(null, $steps...) using ($step) {
+	@include breakpoints($steps...) using ($step) {
 		font-size: font-size($step);
 	}
 }

--- a/scss/api/mixins/_index.scss
+++ b/scss/api/mixins/_index.scss
@@ -11,6 +11,7 @@
 @forward "max-vw";
 @forward "min-vh";
 @forward "min-vw";
+@forward "prefers-motion";
 @forward "range-vh";
 @forward "range-vw";
 @forward "reduced-motion";

--- a/scss/api/mixins/_index.scss
+++ b/scss/api/mixins/_index.scss
@@ -14,3 +14,4 @@
 @forward "range-vh";
 @forward "range-vw";
 @forward "reduced-motion";
+@forward "size";

--- a/scss/api/mixins/_prefers-motion.scss
+++ b/scss/api/mixins/_prefers-motion.scss
@@ -1,0 +1,7 @@
+// Prefers Motion: A query for when the user requests motion.
+
+@mixin prefers-motion {
+    @media not (prefers-reduced-motion: reduce) {
+        @content;
+    }
+}

--- a/scss/api/mixins/_size.scss
+++ b/scss/api/mixins/_size.scss
@@ -1,0 +1,10 @@
+// Size: Shorthand for using the `size()` function across breakpoints.
+
+@use "../functions/" as *;
+@use "breakpoints" as *;
+
+@mixin size($steps...) {
+    @include breakpoints($steps...) using ($step) {
+        @content(size($step));
+    }
+}


### PR DESCRIPTION
### Added

- Added root `_index.scss` as an accessible entry point into API.css.
- Added `size` shorthand mixin for using the `size()` function across breakpoints.
- Added `prefers-motion` media query mixin for when the user requests motion.

### Changed

- Changed `font-size` mixin parameter name from `$values` to intended `$steps`.
- Changed `breakpoints` mixin by removing `$properties`, and to only accept `$values`.
