### PR TITLE
API.css v1.0.0 Beta 4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All relevant changes to API.css will be documented here.
 
+## [1.0.0-beta.4] - 2023-03-15
+
+### Added
+
+- Added `$color-shift` multiplying integer syntax to `tone` function.
+- Added `@content` block support to `font-size` mixin.
+- Added `state` mixin that includes `$true` and/or `$false` state for a given `$selector`.
+- Added `$accent` color variable default.
+- Added optional `/scss/styles/` stylesheet that brings over API defaults to HTML elements, as well as useful defaults to preserve page responsiveness.
+- Added `$time-xs`, `$time-sm`, `$time-md`, `$time-lg`, `$time-xl` and `$time-xxl` variable defaults for transitions/animations.
+
+### Changed
+
+- Changed `$perc` syntax of `shade` and `tint` functions to `$amount`.
+- Changed `$font-size-ratio` default to `1.250` from `1.200`.
+
 ## [1.0.0-beta.3] - 2023-03-10
 
 ### Added
@@ -52,6 +68,7 @@ All relevant changes to API.css will be documented here.
 
 - Initial beta release (cloned from Neo CSS preview branch).
 
+[1.0.0-beta.4]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/JoshuaSand0val/API.css/releases/tag/v1.0.0-beta.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "api.css",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "api.css",
-			"version": "1.0.0-beta.3",
+			"version": "1.0.0-beta.4",
 			"license": "MIT",
 			"dependencies": {
 				"sass": "^1.58.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "api.css",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.4",
 	"description": "A modern CSS API built with SASS/SCSS.",
 	"keywords": [
 		"API.css",

--- a/scss/api/functions/_shade.scss
+++ b/scss/api/functions/_shade.scss
@@ -1,11 +1,11 @@
-// Shade: Darkens $color by $perc, or $color-shift multiplier.
+// Shade: Darkens $color by $amount. A percentage, or a $color-shift multiplier.
 
 @use "../variables/" as *;
 @use "../sass" as *;
 
-@function shade($color, $perc) {
-    @if MATH-is-unitless($perc) {
-        $perc: MATH-clamp(-100%, $color-shift * $perc, 100%);
+@function shade($color, $amount) {
+    @if MATH-is-unitless($amount) {
+        $amount: MATH-clamp(-100%, $color-shift * $amount, 100%);
     }
-    @return COLOR-adjust($color, $lightness: -$perc);
+    @return COLOR-adjust($color, $lightness: -$amount);
 }

--- a/scss/api/functions/_tint.scss
+++ b/scss/api/functions/_tint.scss
@@ -1,11 +1,7 @@
-// Tint: Lightens $color by $perc, or $color-shift multiplier.
+// Tint: Lightens $color by $amount. A percentage, or a $color-shift multiplier.
 
-@use "../variables/" as *;
-@use "../sass" as *;
+@use "shade" as *;
 
-@function tint($color, $perc) {
-    @if MATH-is-unitless($perc) {
-        $perc: MATH-clamp(-100%, $color-shift * $perc, 100%);
-    }
-    @return COLOR-adjust($color, $lightness: +$perc);
+@function tint($color, $amount) {
+    @return shade($color, -$amount);
 }

--- a/scss/api/functions/_tone.scss
+++ b/scss/api/functions/_tone.scss
@@ -1,7 +1,11 @@
-// Tone: Grays $color by $perc.
+// Tone: Grays $color by $amount. A percentage, or a $color-shift multiplier.
 
+@use "../variables/" as *;
 @use "../sass" as *;
 
-@function tone($color, $perc) {
-    @return COLOR-mix(#808080, $color, $weight: $perc);
+@function tone($color, $amount) {
+    @if MATH-is-unitless($amount) {
+        $amount: MATH-min($color-shift * $amount, 100%);
+    }
+    @return COLOR-mix(#808080, $color, $weight: $amount);
 }

--- a/scss/api/mixins/_font-size.scss
+++ b/scss/api/mixins/_font-size.scss
@@ -1,10 +1,16 @@
 // Font Size: Shorthand for setting font-size across breakpoints.
 
 @use "../functions/" as *;
+@use "../sass" as *;
 @use "breakpoints" as *;
 
 @mixin font-size($steps...) {
 	@include breakpoints($steps...) using ($step) {
-		font-size: font-size($step);
+		@content(font-size($step));
+	}
+	@if not META-content-exists() {
+		@include font-size($steps...) using ($size) {
+			font-size: $size;
+		}
 	}
 }

--- a/scss/api/mixins/_index.scss
+++ b/scss/api/mixins/_index.scss
@@ -16,3 +16,4 @@
 @forward "range-vw";
 @forward "reduced-motion";
 @forward "size";
+@forward "state";

--- a/scss/api/mixins/_state.scss
+++ b/scss/api/mixins/_state.scss
@@ -1,0 +1,6 @@
+// State: Includes $true and/or $false state for a given $selector.
+
+@mixin state($selector, $true: null, $false: null) {
+	@content($selector, $true);
+	@content(":not(#{$selector})", $false);
+}

--- a/scss/api/variables/_variables.scss
+++ b/scss/api/variables/_variables.scss
@@ -112,6 +112,14 @@ $radius-lg: 18px !default;
 $radius-xl: 24px !default;
 $radius-xxl: 32px !default;
 
+// Timing Lengths:
+$time-xs: 150ms !default;
+$time-sm: 300ms !default;
+$time-md: 500ms !default;
+$time-lg: 750ms !default;
+$time-xl: 1s !default;
+$time-xxl: 1.5s !default;
+
 // Safe Areas:
 $safe-top: env(safe-area-inset-top) !default;
 $safe-right: env(safe-area-inset-right) !default;

--- a/scss/api/variables/_variables.scss
+++ b/scss/api/variables/_variables.scss
@@ -35,6 +35,10 @@ $colors: (
     "pink": $pink
 ) !default;
 
+// Accent Color:
+$accent: $blue !default;
+$accent: MAP-get($colors, $accent) or $accent;
+
 // Color Schemes:
 $color-scheme: light dark !default;
 $background-color: $white, dark $black !default;

--- a/scss/api/variables/_variables.scss
+++ b/scss/api/variables/_variables.scss
@@ -53,7 +53,7 @@ $scale-ratio: 1.414 !default;
 
 // Font Sizing:
 $font-size: 1em !default;
-$font-size-ratio: 1.200 !default;
+$font-size-ratio: 1.250 !default;
 
 // Font Family:
 $font: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,

--- a/scss/styles/_index.scss
+++ b/scss/styles/_index.scss
@@ -1,0 +1,73 @@
+// Styles: API derived styles for HTML elements.
+
+@use "../api/" as *;
+
+:where(*, ::before, ::after) {
+	box-sizing: border-box;
+	max-width: 100%;
+}
+
+:where(html) {
+	color-scheme: $color-scheme;
+	font-family: $font;
+	font-weight: $weight;
+	line-height: $line-height;
+	word-break: break-word;
+	@include font-size(-1, 0);
+	@include background-color using ($bg) {
+		background-color: $bg;
+		color: text-color($color2: $bg);
+	}
+	@include prefers-motion {
+		scroll-behavior: smooth;
+	}
+}
+
+:where(body) {
+	margin: 0;
+}
+
+:where(h1, h2, h3, h4, h5, h6) {
+	font-family: $font-heading;
+	font-weight: $weight-bold;
+	line-height: $line-height-heading;
+	margin: size(-1) 0;
+}
+
+:where(h1) {
+	@include font-size(3);
+}
+
+:where(h2) {
+	@include font-size(2);
+}
+
+:where(h3) {
+	@include font-size(1);
+}
+
+:where(h4) {
+	@include font-size(0);
+}
+
+:where(h5, sub, sup, small) {
+	@include font-size(-1);
+}
+
+:where(h6) {
+	@include font-size(-2);
+}
+
+:where(b, strong) {
+	font-weight: $weight-bold;
+}
+
+:where(code, samp, pre, kbd) {
+	font-family: $font-mono;
+}
+
+@include background-color using ($bg) {
+	:where(a[href]) {
+		color: text-color($accent, $bg);
+	}
+}


### PR DESCRIPTION
## Added

- Added `$color-shift` multiplying integer syntax to `tone` function.
- Added `@content` block support to `font-size` mixin.
- Added `state` mixin that includes `$true` and/or `$false` state for a given `$selector`.
- Added `$accent` color variable default.
- Added optional `/scss/styles/` stylesheet that brings over API defaults to HTML elements, as well as useful defaults to preserve page responsiveness.
- Added `$time-xs`, `$time-sm`, `$time-md`, `$time-lg`, `$time-xl` and `$time-xxl` variable defaults for transitions/animations.

## Changed

- Changed `$perc` syntax of `shade` and `tint` functions to `$amount`.
- Changed `$font-size-ratio` default to `1.250` from `1.200`.